### PR TITLE
Fix viewport width issue on iOS devices

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Overpass&display=swap');
 
 html, body {
+    position: fixed;
     width: 100%;
     height: 100%;
     margin: 0px;


### PR DESCRIPTION
I'm not sure how to test this as of right now, but I think adding the CSS rule "position: fixed" to the body tag might fix the issue